### PR TITLE
chore: Enable idiomatic version file for node

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]


### PR DESCRIPTION
## What does this PR do?

```
mise WARN  deprecated [idiomatic_version_file_enable_tools]:
Idiomatic version files like ~/Documents/Projects/pulsate-dev/website/.node-version are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.

You can remove this warning by explicitly enabling idiomatic version files for node with:

    mise settings add idiomatic_version_file_enable_tools node

You can disable idiomatic version files with:

    mise settings add idiomatic_version_file_enable_tools "[]"

See https://github.com/jdx/mise/discussions/4345 for more information.
```

According to this warning above, `mise` will introduce a breaking change about treating `.node-version`. So I write `mise.toml` configuration file to allow mise using `.node-version` as before.
