### PR TITLE
chore: Add astro package rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>pulsate-dev/renovate-conf"]
+  "extends": ["github>pulsate-dev/renovate-conf"],
+  "packageRules": [
+    {
+      "groupName": "Astro packages",
+      "matchPackageNames": [
+        "@astrojs/**",
+        "astro",
+        "starlight-openapi"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Add a package rule for Astro.js and its plugins to `renovate.json`.