### PR TITLE
hotfix: スキーマファイルをunpkg経由で`@pulsate-dev/api-schema`から落とすように

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -51,7 +51,7 @@ export default defineConfig({
             label: "API Reference",
             // TODO: `main` からタグに切り替える
             schema:
-              "https://raw.githubusercontent.com/pulsate-dev/pulsate/main/resources/schema.json",
+              "https://unpkg.com/@pulsate-dev/api-schema@latest/schema.json",
           },
         ]),
       ],


### PR DESCRIPTION
#698 

## What does this PR do?
- pulsateのスキーマは`@pulsate-dev/api-schema`にある
- starlightの設定ではnpmを指定してスキーマを落とせない
  - ので、unpkg.comを経由してダウンロードするように変更

## Additional information

